### PR TITLE
PostMessage no longer sends results to the worker

### DIFF
--- a/GUI/gui.js
+++ b/GUI/gui.js
@@ -100,7 +100,12 @@ dbFileElm.onchange = function() {
 			execEditorContents();
 		};
 		tic();
-		worker.postMessage({action:'open',buffer:r.result});
+		try {
+			worker.postMessage({action:'open',buffer:r.result}, [r.result]);
+		}
+		catch(exception) {
+			worker.postMessage({action:'open',buffer:r.result});
+		}
 	}
 	r.readAsArrayBuffer(f);
 }


### PR DESCRIPTION
When opening a file, r.results is no longer sent as part of the
'transferlist'. This would case a 'DataCloneException' in Internet
explorer 11. In the future I may look to see if I can have the worker
read the file directly.
